### PR TITLE
add an attribute macro version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,32 @@ pub fn auto_const_array(input: TokenStream) -> TokenStream {
     const_array(input).unwrap_or_else(|e| TokenStream::from(e.to_compile_error()))
 }
 
+/// Declare a new const array without specify length.
+/// It helps when apply conditional compilation to part of a const array.
+/// Similar to [`auto_const_array`], but using attribute macro syntax.
+///
+/// # Syntax
+/// The macro wraps any number of const array declarations(with length `_`).
+///
+/// ```rust
+/// use auto_const_array::auto_const_array_attr as auto_const_array;
+///
+/// /// Common array with public visibility.
+/// #[auto_const_array]
+/// pub const ARRAY_COMMON: [u8; _] = [1, 2, 4];
+/// /// Special array with cfg conditional compiling.
+/// #[auto_const_array]
+/// const ARRAY_WITH_ATTR: [u8; _] = [
+///     1,
+///     #[cfg(unix)]
+///     2,
+/// ];
+/// ```
+#[proc_macro_attribute]
+pub fn auto_const_array_attr(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    const_array(item).unwrap_or_else(|e| TokenStream::from(e.to_compile_error()))
+}
+
 fn const_array(input: TokenStream) -> Result<TokenStream> {
     let parser = Punctuated::<ConstArray, Token![;]>::parse_terminated;
     let args = parser.parse(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,9 +34,6 @@ pub fn auto_const_array(input: TokenStream) -> TokenStream {
 /// It helps when apply conditional compilation to part of a const array.
 /// Similar to [`auto_const_array`], but using attribute macro syntax.
 ///
-/// # Syntax
-/// The macro wraps any number of const array declarations(with length `_`).
-///
 /// ```rust
 /// use auto_const_array::auto_const_array_attr as auto_const_array;
 ///


### PR DESCRIPTION
Introduced `auto_const_array_attr`, which is similar to the original version, but be used as an attribute macro.

There are several benefits:
* Code can be formatted by rustfmt
* Reduce an indent
* Better readability

Regarding the name of this macro, I just simply suffix with `_attr`, we can discuss it.